### PR TITLE
create login and signup view

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,28 +1,11 @@
-import { useEffect } from 'react';
+import UserConversationsProvider from './providers/UserConversationsProvider';
+import ChicaChicaApp from './components/ChicaChicaApp';
 
 function App() {
-    useEffect(() => {
-        const fetchData = async () => {
-            const response = await fetch('http://localhost:3001/');
-            const data = await response.json();
-            console.log(data);
-        };
-        fetchData();
-    }, []);
-
     return (
-        <>
-            <div id="app" className="h-dvh bg-gray-50">
-                <div className="grid grid-cols-12 gap-4 min-h-full">
-                    <div id="chat-nav" className="col-span-3 p-6 shadow-xl">
-                        <h1 className="text-2xl font-bold">chicahan</h1>
-                    </div>
-                    <div id="chat-view" className="col-span-9 p-8 shadow-xl">
-                        <h1>Hello Vite + React!</h1>
-                    </div>
-                </div>
-            </div>
-        </>
+        <UserConversationsProvider>
+            <ChicaChicaApp />
+        </UserConversationsProvider>
     );
 }
 

--- a/frontend/src/components/ChicaChicaApp.tsx
+++ b/frontend/src/components/ChicaChicaApp.tsx
@@ -1,0 +1,15 @@
+import { useUserConversations } from '../providers/UserConversationsProvider';
+import LoginView from './LoginView';
+import MainView from './MainView';
+
+function ChicaChicaApp() {
+    const { loggedInUser } = useUserConversations();
+
+    return (
+        <div id="app" className="h-dvh bg-emerald-50">
+            {loggedInUser ? <MainView /> : <LoginView />}
+        </div>
+    );
+}
+
+export default ChicaChicaApp;

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,31 @@
+interface LoadingSpinnerProps {
+    size?: 'sm' | 'md' | 'lg';
+    color?: string;
+    className?: string;
+}
+
+function LoadingSpinner({ size = 'sm', color = 'text-white', className = '' }: LoadingSpinnerProps) {
+    const sizeClasses = {
+        sm: 'h-4 w-4',
+        md: 'h-6 w-6',
+        lg: 'h-8 w-8',
+    };
+
+    return (
+        <svg
+            className={`animate-spin ${sizeClasses[size]} ${color} ${className}`}
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+        >
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+        </svg>
+    );
+}
+
+export default LoadingSpinner;

--- a/frontend/src/components/LoginView.tsx
+++ b/frontend/src/components/LoginView.tsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from 'react';
+import { User } from '../utils/types';
+import { useUserConversations } from '../providers/UserConversationsProvider';
+import { useUsersApi } from '../hooks/useUsersApi';
+import CreateNewUserForm from './CreateNewUserForm';
+
+function LoginView() {
+    const { logInUser } = useUserConversations();
+    const { fetchUsers, loading } = useUsersApi();
+    const [fetchedUsers, setFetchedUsers] = useState<User[]>([]);
+    const [isCreatingAccount, setIsCreatingAccount] = useState(false);
+    const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+
+    const loadUsers = async () => {
+        try {
+            const fetchedUsers = await fetchUsers();
+            setFetchedUsers(fetchedUsers);
+            // Automatically show create account form if no users exist
+            if (fetchedUsers.length === 0) {
+                setIsCreatingAccount(true);
+            }
+        } catch (err) {
+            console.error('Failed to load users:', err);
+            // Still allow creating new accounts even if fetching fails
+        }
+    };
+
+    const handleSelectUser = (userId: string) => {
+        setSelectedUserId(userId);
+    };
+
+    const handleLogin = () => {
+        const user = fetchedUsers.find((u) => u.id === selectedUserId);
+        if (user) {
+            logInUser(user);
+        }
+    };
+
+    const handleUserCreated = (user: User) => {
+        logInUser(user);
+    };
+
+    const handleCreateNewAccount = () => {
+        setIsCreatingAccount(true);
+        setSelectedUserId(null);
+    };
+
+    const handleBackFromCreate = () => {
+        setIsCreatingAccount(false);
+    };
+
+    useEffect(() => {
+        loadUsers();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <div className="min-h-screen flex items-center justify-center">
+            <div className="bg-white rounded-xl shadow-lg p-8 w-full max-w-md">
+                <div className="text-center mb-8">
+                    <h1 className="text-3xl font-bold text-gray-800 mb-2">ChicaChica</h1>
+                    <p className="text-gray-500 text-sm italic">
+                        From the Filipino term &quot;Chika Chika&quot;
+                        <br />
+                        It means &quot;chit-chat&quot;, gossip, or casual conversation;
+                    </p>
+                </div>
+
+                {loading && fetchedUsers.length === 0 ? (
+                    <div className="animate-pulse">
+                        <div className="space-y-2 mb-4">
+                            <div className="h-16 bg-gray-200 rounded-lg"></div>
+                            <div className="h-16 bg-gray-200 rounded-lg"></div>
+                        </div>
+                        <div className="h-12 bg-gray-200 rounded-lg mb-3"></div>
+                        <div className="h-12 bg-gray-200 rounded-lg"></div>
+                    </div>
+                ) : !isCreatingAccount ? (
+                    <div>
+                        <h2 className="text-lg font-semibold text-gray-700 mb-4">Select an account</h2>
+
+                        {fetchedUsers.length === 0 ? (
+                            <div className="text-center py-8 text-gray-500">
+                                No existing users found. Create a new account to get started!
+                            </div>
+                        ) : (
+                            <div className="mb-4 space-y-2">
+                                {fetchedUsers.map((user) => (
+                                    <button
+                                        key={user.id}
+                                        onClick={() => handleSelectUser(user.id)}
+                                        className={`w-full p-3 rounded-lg border cursor-pointer transition-all flex items-center justify-between
+                                        ${
+                                            selectedUserId === user.id
+                                                ? 'border-blue-500 bg-blue-50 border-2'
+                                                : 'border-gray-200 hover:bg-gray-50'
+                                        }`}
+                                    >
+                                        <div className="text-left">
+                                            <div className="font-medium text-gray-800">{user.displayName}</div>
+                                            {user.email && <div className="text-xs text-gray-500">{user.email}</div>}
+                                        </div>
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+
+                        {selectedUserId && (
+                            <button
+                                onClick={handleLogin}
+                                className="w-full py-3 px-4 cursor-pointer bg-blue-500 hover:bg-blue-600 text-white rounded-lg 
+                                         font-medium transition-colors mb-3"
+                            >
+                                Continue
+                            </button>
+                        )}
+
+                        <div className="flex items-center my-5">
+                            <div className="flex-1 h-px bg-gray-200" />
+                            <span className="px-3 text-sm text-gray-400">or</span>
+                            <div className="flex-1 h-px bg-gray-200" />
+                        </div>
+
+                        <button
+                            onClick={handleCreateNewAccount}
+                            className="w-full py-3 px-4 cursor-pointer bg-white hover:bg-blue-50 text-blue-500 
+                                     border border-blue-500 rounded-lg font-medium transition-colors"
+                        >
+                            Create New Account
+                        </button>
+                    </div>
+                ) : (
+                    <CreateNewUserForm
+                        onUserCreated={handleUserCreated}
+                        onBack={fetchedUsers.length > 0 ? handleBackFromCreate : undefined}
+                    />
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default LoginView;

--- a/frontend/src/components/MainView.tsx
+++ b/frontend/src/components/MainView.tsx
@@ -1,0 +1,14 @@
+function MainView() {
+    return (
+        <div className="grid grid-cols-12 gap-4 min-h-full">
+            <div id="chat-nav" className="col-span-3 p-6 shadow-xl">
+                <h1 className="text-2xl font-bold">chicahan</h1>
+            </div>
+            <div id="chat-view" className="col-span-9 p-8 shadow-xl">
+                <h1>Hello Vite + React!</h1>
+            </div>
+        </div>
+    );
+}
+
+export default MainView;

--- a/frontend/src/hooks/useUsersApi.ts
+++ b/frontend/src/hooks/useUsersApi.ts
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { User, UserStatus } from '../utils/types';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
+
+interface UserPayload {
+    id: string;
+    display_name: string;
+    email?: string;
+    status: 'online' | 'away' | 'offline';
+    created_at: string;
+    last_seen: string;
+}
+
+const formatUserPayload = (userPayload: UserPayload): User => {
+    return {
+        id: userPayload.id,
+        displayName: userPayload.display_name,
+        email: userPayload.email || '',
+        status: userPayload.status as UserStatus,
+        createdAt: new Date(userPayload.created_at),
+        lastSeen: new Date(userPayload.last_seen),
+    };
+};
+
+export const useUsersApi = () => {
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const fetchUsers = async (): Promise<User[]> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/users`);
+            if (!response.ok) {
+                throw new Error(`Failed to fetch users: ${response.statusText}`);
+            }
+            const data: UserPayload[] = await response.json();
+            return data.map(formatUserPayload);
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to fetch users';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const createUser = async (displayName: string, email?: string): Promise<User> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/users`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    display_name: displayName,
+                    email: email || null,
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to create user: ${response.statusText}`);
+            }
+
+            const data: UserPayload = await response.json();
+            return formatUserPayload(data);
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to create user';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const getUserById = async (id: string): Promise<User> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/users/${id}`);
+            if (!response.ok) {
+                throw new Error(`Failed to fetch user: ${response.statusText}`);
+            }
+            const data: UserPayload = await response.json();
+            return formatUserPayload(data);
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to fetch user';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const updateUserStatus = async (id: string, status: UserStatus): Promise<User> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/users/${id}/status`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ status }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to update user status: ${response.statusText}`);
+            }
+
+            const data: UserPayload = await response.json();
+            return formatUserPayload(data);
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to update user status';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return {
+        fetchUsers,
+        createUser,
+        getUserById,
+        updateUserStatus,
+        loading,
+        error,
+    };
+};

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,24 +1,25 @@
 {
-  "compilerOptions": {
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "ESNext",
-    "skipLibCheck": true,
+    "compilerOptions": {
+        "target": "ES2020",
+        "useDefineForClassFields": true,
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+        "types": ["vite/client"],
 
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-    "jsx": "react-jsx",
+        /* Bundler mode */
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "isolatedModules": true,
+        "moduleDetection": "force",
+        "noEmit": true,
+        "jsx": "react-jsx",
 
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
-  },
-  "include": ["src"]
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "include": ["src", "src/**/*.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -39,10 +39,15 @@
         "typescript": "^5.7.3"
     },
     "lint-staged": {
-        "**/*.{ts,tsx}": [
+        "frontend/**/*.{ts,tsx}": [
             "prettier --write",
             "eslint --fix --max-warnings=0 --no-warn-ignored",
-            "tsc-files --noEmit"
+            "bash -c 'cd frontend && npx tsc-files --noEmit'"
+        ],
+        "backend/**/*.{ts,tsx}": [
+            "prettier --write",
+            "eslint --fix --max-warnings=0 --no-warn-ignored",
+            "bash -c 'cd backend && npx tsc-files --noEmit'"
         ],
         "**/*.{js,jsx}": [
             "prettier --write",


### PR DESCRIPTION
This pull request refactors the frontend authentication flow and user management for the ChicaChica app, introducing a provider-based architecture for user sessions, a new login and account creation experience, and reusable API hooks. The changes improve separation of concerns, user experience, and code maintainability.

**Authentication and User Management Flow**
* Replaced the previous hardcoded UI in `App.tsx` with a provider-based structure using `UserConversationsProvider` and a new root component `ChicaChicaApp`, which conditionally renders either the main app view or the login flow based on user authentication state. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL1-R8) [[2]](diffhunk://#diff-2af6e6323d1114de5f9479bde462ccd993eb646233bf1e24b2989b56757a1b9cR1-R15)
* Added a new `LoginView` component that handles user selection, login, and account creation, including smooth transitions between selecting an existing user and creating a new account.
* Implemented the `CreateNewUserForm` component, allowing new users to sign up with validation, error handling, and integration with backend API responses.

**Reusable API and Utility Components**
* Introduced the `useUsersApi` hook to encapsulate all user-related API calls (fetch, create, update status, get by ID), including loading and error state management.
* Added a reusable `LoadingSpinner` component for consistent loading indicators across the UI.

**UI Consistency and Theming**
* Updated the main app layout via the new `MainView` component, maintaining the previous grid-based chat navigation and view structure, but now rendered only for authenticated users.

<img width="1085" height="762" alt="image" src="https://github.com/user-attachments/assets/00a63f1c-705c-4b8f-873c-1f9bbe6d612a" />

<img width="580" height="660" alt="image" src="https://github.com/user-attachments/assets/c92155a7-a701-46c8-9009-e42cf355dd0a" />
