### PR TITLE
add conversation and message services

### DIFF
--- a/backend/src/db/init.ts
+++ b/backend/src/db/init.ts
@@ -83,7 +83,7 @@ async function initializeDatabase(skipPrompt = false) {
         await sql`
       CREATE TABLE conversations (
         id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-        title VARCHAR(255) NOT NULL,
+        title VARCHAR(255),
         created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
         created_by UUID REFERENCES users(id) ON DELETE SET NULL
       )

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -1,0 +1,3 @@
+export interface QueryResultWithCount {
+    count: number;
+}

--- a/backend/src/services/conversationService.ts
+++ b/backend/src/services/conversationService.ts
@@ -1,0 +1,361 @@
+import { sql } from '../db/client';
+import { processDatabaseError } from '../db/errors';
+import { QueryResultWithCount } from '../db/types';
+
+export interface Conversation {
+    id: string;
+    title: string | null;
+    created_at: Date;
+    created_by?: string;
+    is_custom_title: boolean;
+}
+
+export interface ConversationParticipant {
+    user_id: string;
+    display_name: string;
+    email?: string;
+    status?: string;
+    joined_at: Date;
+    is_admin: boolean;
+}
+
+export interface ConversationWithParticipants extends Conversation {
+    participants: Array<ConversationParticipant>;
+}
+
+export class ConversationService {
+    /**
+     * @param title - The title of the conversation
+     * @param createdBy - The user ID of the creator
+     * @param participantIds - The user IDs of the participants (should include the creator's id)
+     * @returns The created conversation object
+     * @throws {ForeignKeyConstraintError} When created_by user doesn't exist
+     * @throws {DatabaseError} When database operation fails
+     */
+    async createConversation(title: string | null, createdBy: string, participantIds: string[]): Promise<Conversation> {
+        try {
+            const result = await sql`
+                INSERT INTO conversations (title, created_by)
+                VALUES (${title}, ${createdBy})
+                RETURNING *
+            `;
+            const conversation = {
+                ...result[0],
+                is_custom_title: title !== null,
+            } as Conversation;
+
+            if (participantIds.length > 0) {
+                // Using unnest for bulk insert with proper parameterization
+                await sql`
+                    INSERT INTO conversation_participants (conversation_id, user_id, is_admin)
+                    SELECT * FROM UNNEST(
+                        ${participantIds.map(() => conversation.id)}::uuid[],
+                        ${participantIds}::uuid[],
+                        ${participantIds.map((userId) => userId === createdBy)}::boolean[]
+                    )
+                `;
+            }
+
+            return conversation;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns The conversation with participants or null if not found
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getConversationById(conversationId: string): Promise<ConversationWithParticipants | null> {
+        try {
+            const result = await sql`
+                SELECT * FROM conversations
+                WHERE id = ${conversationId}
+            `;
+
+            if (!result[0]) return null;
+
+            const conversation = {
+                ...result[0],
+                is_custom_title: result[0].title !== null,
+            } as Conversation;
+
+            const participants = await sql`
+                SELECT 
+                    cp.user_id,
+                    u.display_name,
+                    u.email,
+                    u.status,
+                    cp.joined_at,
+                    cp.is_admin
+                FROM conversation_participants cp
+                JOIN users u ON cp.user_id = u.id
+                WHERE cp.conversation_id = ${conversationId}
+                ORDER BY cp.joined_at
+            `;
+
+            return {
+                ...conversation,
+                participants: participants as ConversationParticipant[],
+            };
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns List of conversations the user is a participant of
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getConversationsForUser(userId: string, limit = 50, offset = 0): Promise<Conversation[]> {
+        try {
+            const result = await sql`
+                SELECT DISTINCT c.*
+                FROM conversations c
+                JOIN conversation_participants cp ON c.id = cp.conversation_id
+                WHERE cp.user_id = ${userId}
+                ORDER BY c.created_at DESC
+                LIMIT ${limit}
+                OFFSET ${offset}
+            `;
+
+            return result.map((row) => ({
+                ...row,
+                is_custom_title: row.title !== null,
+            })) as Conversation[];
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns The count of conversations the user is a participant of
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getConversationsCountForUser(userId: string): Promise<number> {
+        try {
+            const result = await sql`
+                SELECT COUNT(DISTINCT c.id) as count
+                FROM conversations c
+                JOIN conversation_participants cp ON c.id = cp.conversation_id
+                WHERE cp.user_id = ${userId}
+            `;
+
+            return Number(result[0].count);
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns List of participants for a specific conversation
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getParticipantsForConversation(conversationId: string): Promise<ConversationParticipant[]> {
+        try {
+            const result = await sql`
+                SELECT 
+                    cp.user_id,
+                    u.display_name,
+                    u.email,
+                    u.status,
+                    cp.joined_at,
+                    cp.is_admin
+                FROM conversation_participants cp
+                JOIN users u ON cp.user_id = u.id
+                WHERE cp.conversation_id = ${conversationId}
+                ORDER BY cp.joined_at
+            `;
+
+            return result as ConversationParticipant[];
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns A mapping of conversation IDs to their unread message counts for a user
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getUnreadCountsForUser(userId: string): Promise<{ [conversationId: string]: number }> {
+        try {
+            const result = await sql`
+                SELECT 
+                    c.id as conversation_id,
+                    COUNT(CASE 
+                        WHEN m.id IS NOT NULL 
+                            AND m.author_id != ${userId}
+                            AND (
+                                cp.last_read_message_id IS NULL 
+                                OR m.timestamp > (
+                                    SELECT timestamp FROM messages 
+                                    WHERE id = cp.last_read_message_id
+                                )
+                            ) THEN 1 
+                    END) as unread_count
+                FROM conversations c
+                JOIN conversation_participants cp ON c.id = cp.conversation_id
+                LEFT JOIN messages m ON m.conversation_id = c.id 
+                    AND m.is_deleted = false
+                WHERE cp.user_id = ${userId}
+                GROUP BY c.id, cp.last_read_message_id
+            `;
+
+            const conversationIdToUnreadCount: { [conversationId: string]: number } = {};
+            (result as { conversation_id: string; unread_count: string }[]).forEach((row) => {
+                conversationIdToUnreadCount[row.conversation_id] = Number(row.unread_count);
+            });
+
+            return conversationIdToUnreadCount;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns A mapping of conversation IDs to their participants
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getParticipantsForConversations(
+        conversationIds: string[]
+    ): Promise<{ [conversationId: string]: ConversationParticipant[] }> {
+        if (conversationIds.length === 0) return {};
+
+        try {
+            const result = await sql`
+                SELECT 
+                    cp.conversation_id,
+                    cp.user_id,
+                    u.display_name,
+                    u.email,
+                    u.status,
+                    cp.joined_at,
+                    cp.is_admin
+                FROM conversation_participants cp
+                JOIN users u ON cp.user_id = u.id
+                WHERE cp.conversation_id = ANY(${conversationIds})
+                ORDER BY cp.conversation_id, cp.joined_at
+            `;
+
+            const conversationIdToParticipants: { [conversationId: string]: ConversationParticipant[] } = {};
+
+            (result as Array<{ conversation_id: string } & ConversationParticipant>).forEach((row) => {
+                const { conversation_id, ...participant } = row;
+
+                if (!conversationIdToParticipants[conversation_id]) {
+                    conversationIdToParticipants[conversation_id] = [];
+                }
+
+                conversationIdToParticipants[conversation_id].push(participant);
+            });
+
+            // Ensure all requested conversations have an entry (empty array if no participants)
+            conversationIds.forEach((id) => {
+                if (!(id in conversationIdToParticipants)) {
+                    conversationIdToParticipants[id] = [];
+                }
+            });
+
+            return conversationIdToParticipants;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns True if participant was added or no-op if already a participant
+     * @throws {ForeignKeyConstraintError} When conversation_id or user_id doesn't exist
+     * @throws {DatabaseError} When database operation fails
+     */
+    async addParticipantToConversation(conversationId: string, userId: string, isAdmin = false): Promise<boolean> {
+        try {
+            await sql`
+                INSERT INTO conversation_participants (conversation_id, user_id, is_admin)
+                VALUES (${conversationId}, ${userId}, ${isAdmin})
+                ON CONFLICT (conversation_id, user_id) DO NOTHING
+            `;
+            return true;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns True if participant was removed
+     * @throws {DatabaseError} When database operation fails
+     */
+    async removeParticipantFromConversation(conversationId: string, userId: string): Promise<boolean> {
+        try {
+            const result = await sql`
+                DELETE FROM conversation_participants
+                WHERE conversation_id = ${conversationId}
+                    AND user_id = ${userId}
+            `;
+            return (result as unknown as QueryResultWithCount).count > 0;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns True if user is a participant of the conversation
+     * @throws {DatabaseError} When database operation fails
+     */
+    async isUserInConversation(conversationId: string, userId: string): Promise<boolean> {
+        try {
+            const result = await sql`
+                SELECT EXISTS(
+                    SELECT 1 FROM conversation_participants
+                    WHERE conversation_id = ${conversationId}
+                        AND user_id = ${userId}
+                ) as exists
+            `;
+            const row = result[0] as { exists: boolean };
+            return row?.exists || false;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns true if last read message was updated, false otherwise
+     * @throws {DatabaseError} When database operation fails
+     */
+    async updateLastReadMessage(conversationId: string, userId: string, messageId: string): Promise<boolean> {
+        try {
+            const result = await sql`
+                UPDATE conversation_participants
+                SET last_read_message_id = ${messageId}
+                WHERE conversation_id = ${conversationId}
+                    AND user_id = ${userId}
+            `;
+            return (result as unknown as QueryResultWithCount).count > 0;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns The updated conversation or null if not found
+     * @throws {DatabaseError} When database operation fails
+     */
+    async updateConversationTitle(conversationId: string, title: string | null): Promise<Conversation | null> {
+        try {
+            const result = await sql`
+                UPDATE conversations
+                SET title = ${title}
+                WHERE id = ${conversationId}
+                RETURNING *
+            `;
+
+            if (!result[0]) return null;
+
+            return {
+                ...result[0],
+                is_custom_title: title !== null,
+            } as Conversation;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+}

--- a/backend/src/services/messageService.ts
+++ b/backend/src/services/messageService.ts
@@ -1,0 +1,217 @@
+import { sql } from '../db/client';
+import { processDatabaseError } from '../db/errors';
+import { QueryResultWithCount } from '../db/types';
+
+export interface Message {
+    id: string;
+    conversation_id: string;
+    author_id: string;
+    content: string;
+    timestamp: Date;
+    edited_at?: Date | null;
+    is_deleted: boolean;
+    created_at: Date;
+}
+
+export interface MessageWithAuthor extends Message {
+    author_name: string;
+    author_email?: string;
+    author_status?: string;
+}
+
+export class MessageService {
+    /**
+     * @returns The created message
+     * @throws {ForeignKeyConstraintError} When conversation_id or author_id doesn't exist
+     * @throws {DatabaseError} When database operation fails
+     */
+    async createMessage(conversationId: string, authorId: string, content: string): Promise<Message> {
+        try {
+            const result = await sql`
+                INSERT INTO messages (conversation_id, author_id, content)
+                VALUES (${conversationId}, ${authorId}, ${content})
+                RETURNING *
+            `;
+            return result[0] as Message;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns Messages in descending order by timestamp
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getMessagesForConversation(conversationId: string, limit = 50, offset = 0): Promise<MessageWithAuthor[]> {
+        try {
+            const result = await sql`
+                SELECT 
+                    m.*,
+                    u.display_name as author_name,
+                    u.email as author_email,
+                    u.status as author_status
+                FROM messages m
+                JOIN users u ON m.author_id = u.id
+                WHERE m.conversation_id = ${conversationId}
+                    AND m.is_deleted = false
+                ORDER BY m.timestamp DESC
+                LIMIT ${limit}
+                OFFSET ${offset}
+            `;
+            return result as MessageWithAuthor[];
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns The message or null if not found
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getMessageById(messageId: string): Promise<Message | null> {
+        try {
+            const result = await sql`
+                SELECT * FROM messages
+                WHERE id = ${messageId}
+            `;
+            return (result[0] as Message) || null;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns The updated message or null if not found
+     * @throws {DatabaseError} When database operation fails
+     */
+    async updateMessage(messageId: string, content: string): Promise<Message | null> {
+        try {
+            const result = await sql`
+                UPDATE messages
+                SET content = ${content},
+                    edited_at = CURRENT_TIMESTAMP
+                WHERE id = ${messageId}
+                RETURNING *
+            `;
+            return (result[0] as Message) || null;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns true if a message was marked as deleted, false otherwise
+     * @throws {DatabaseError} When database operation fails
+     */
+    async deleteMessage(messageId: string): Promise<boolean> {
+        try {
+            const result = await sql`
+                UPDATE messages
+                SET is_deleted = true
+                WHERE id = ${messageId}
+            `;
+            return (result as unknown as QueryResultWithCount).count > 0;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns The count of non-deleted messages in a conversation
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getMessageCount(conversationId: string): Promise<number> {
+        try {
+            const result = await sql`
+                SELECT COUNT(*) as count
+                FROM messages
+                WHERE conversation_id = ${conversationId}
+                    AND is_deleted = false
+            `;
+            return Number(result[0].count);
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns A mapping of conversation IDs to their message counts
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getMessageCountsForConversations(conversationIds: string[]): Promise<{ [conversationId: string]: number }> {
+        if (conversationIds.length === 0) return {};
+
+        try {
+            const result = await sql`
+                SELECT 
+                    conversation_id,
+                    COUNT(*) as count
+                FROM messages
+                WHERE conversation_id = ANY(${conversationIds})
+                    AND is_deleted = false
+                GROUP BY conversation_id
+            `;
+
+            const countMap: { [conversationId: string]: number } = {};
+            (result as { conversation_id: string; count: string }[]).forEach((row) => {
+                countMap[row.conversation_id] = Number(row.count);
+            });
+
+            // Ensure all requested conversations have an entry (0 if no messages)
+            conversationIds.forEach((id) => {
+                if (!(id in countMap)) {
+                    countMap[id] = 0;
+                }
+            });
+
+            return countMap;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+
+    /**
+     * @returns A mapping of conversation IDs to their last message with author details (null if no messages)
+     * @throws {DatabaseError} When database operation fails
+     */
+    async getLastMessagesForConversations(
+        conversationIds: string[]
+    ): Promise<{ [conversationId: string]: MessageWithAuthor | null }> {
+        if (conversationIds.length === 0) return {};
+
+        try {
+            const result = await sql`
+                WITH ranked_messages AS (
+                    SELECT 
+                        m.*,
+                        u.display_name as author_name,
+                        u.email as author_email,
+                        u.status as author_status,
+                        ROW_NUMBER() OVER (PARTITION BY m.conversation_id ORDER BY m.timestamp DESC) as row_num
+                    FROM messages m
+                    JOIN users u ON m.author_id = u.id
+                    WHERE m.conversation_id = ANY(${conversationIds})
+                        AND m.is_deleted = false
+                )
+                SELECT * FROM ranked_messages
+                WHERE row_num = 1
+            `;
+
+            const messageMap: { [conversationId: string]: MessageWithAuthor | null } = {};
+
+            // Initialize all conversations with null
+            conversationIds.forEach((id) => {
+                messageMap[id] = null;
+            });
+
+            // Populate with actual messages where they exist
+            (result as (MessageWithAuthor & { row_num: number })[]).forEach(({ row_num: _, ...message }) => {
+                messageMap[message.conversation_id] = message;
+            });
+
+            return messageMap;
+        } catch (error) {
+            throw processDatabaseError(error);
+        }
+    }
+}

--- a/backend/src/services/userService.ts
+++ b/backend/src/services/userService.ts
@@ -12,6 +12,7 @@ export interface User {
 
 export class UserService {
     /**
+     * @returns The created user
      * @throws {UniqueConstraintError} When email already exists
      * @throws {DatabaseError} When database operation fails
      */
@@ -29,6 +30,7 @@ export class UserService {
     }
 
     /**
+     * @returns The user or null if not found
      * @throws {DatabaseError} When database operation fails
      */
     async getUserById(id: string): Promise<User | null> {
@@ -43,6 +45,7 @@ export class UserService {
     }
 
     /**
+     * @returns The user or null if not found
      * @throws {DatabaseError} When database operation fails
      */
     async getUserByEmail(email: string): Promise<User | null> {
@@ -57,6 +60,7 @@ export class UserService {
     }
 
     /**
+     * @returns The updated user or null if not found
      * @throws {DatabaseError} When database operation fails
      */
     async updateUserStatus(id: string, status: 'online' | 'away' | 'offline'): Promise<User | null> {
@@ -74,6 +78,7 @@ export class UserService {
     }
 
     /**
+     * @returns List of all users
      * @throws {DatabaseError} When database operation fails
      */
     async getAllUsers(): Promise<User[]> {


### PR DESCRIPTION
This pull request introduces significant improvements to the backend service layer for conversations and messages. It adds new service classes for handling conversations and messages, defines supporting TypeScript interfaces, and refines the user service documentation for clarity. The changes enhance modularity, error handling, and provide a more robust API for managing chat conversations, participants, and messages.

**Conversation Service Enhancements:**

* Added a new `ConversationService` class in `backend/src/services/conversationService.ts` with comprehensive methods for creating conversations, managing participants, updating titles, retrieving unread counts, and more. This includes robust error handling and clear TypeScript interfaces for conversations and participants.
* Modified the database schema in `backend/src/db/init.ts` so the `title` field in the `conversations` table is now nullable, allowing conversations without a title.
* Introduced the `QueryResultWithCount` interface in `backend/src/db/types.ts` to standardize handling of query results that include row counts, used in participant and message management.

**Message Service Enhancements:**

* Added a new `MessageService` class in `backend/src/services/messageService.ts` with methods for creating, retrieving, updating, deleting, and counting messages, as well as fetching last messages and message counts per conversation. Includes strong error handling and TypeScript interfaces for messages and authors.

**User Service Documentation Improvements:**

* Updated JSDoc comments in `backend/src/services/userService.ts` to clarify return values and error handling for user creation, lookup, status updates, and listing. This makes the API easier to understand and use. [[1]](diffhunk://#diff-37446ddb3cdcd8e698a393c6f26dff34a093a62ebd4862999012bc2ff2dc3a32R15) [[2]](diffhunk://#diff-37446ddb3cdcd8e698a393c6f26dff34a093a62ebd4862999012bc2ff2dc3a32R33) [[3]](diffhunk://#diff-37446ddb3cdcd8e698a393c6f26dff34a093a62ebd4862999012bc2ff2dc3a32R48) [[4]](diffhunk://#diff-37446ddb3cdcd8e698a393c6f26dff34a093a62ebd4862999012bc2ff2dc3a32R63) [[5]](diffhunk://#diff-37446ddb3cdcd8e698a393c6f26dff34a093a62ebd4862999012bc2ff2dc3a32R81)