### PR TITLE
add api hooks and providers

### DIFF
--- a/frontend/src/hooks/useConversationsApi.ts
+++ b/frontend/src/hooks/useConversationsApi.ts
@@ -1,0 +1,370 @@
+import { useState } from 'react';
+
+import { Conversation, Message, UserStatus } from '../utils/types';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api';
+
+interface ParticipantApiPayload {
+    user_id: string;
+    display_name: string;
+    email?: string;
+    status?: string;
+    joined_at: string;
+    is_admin: boolean;
+    last_read_message_id?: string | null;
+}
+
+interface MessageApiPayload {
+    id: string;
+    conversation_id: string;
+    author_id: string;
+    content: string;
+    timestamp: string;
+    edited_at?: string | null;
+    is_deleted: boolean;
+    created_at: string;
+    author_name: string;
+    author_email?: string;
+    author_status?: string;
+}
+
+interface BaseConversationApiPayload {
+    id: string;
+    title: string;
+    created_at: string;
+    created_by?: string;
+    is_custom_title: boolean;
+}
+
+interface ConversationApiPayload extends BaseConversationApiPayload {
+    participants: ParticipantApiPayload[];
+    last_message?: MessageApiPayload | null;
+    total_messages: number;
+    unread_count: number;
+}
+
+type FetchUserConversationsApiPayload = {
+    conversations: ConversationApiPayload[];
+    total: number;
+};
+
+type FetchUserConversationsPayload = {
+    conversations: Conversation[];
+    total: number;
+};
+
+const formatMessage = ({
+    id,
+    author_id,
+    content,
+    timestamp,
+    author_name,
+    author_email,
+    author_status,
+}: MessageApiPayload): Message => {
+    return {
+        id,
+        author: {
+            id: author_id,
+            displayName: author_name,
+            email: author_email || '',
+            status: (author_status || 'offline') as UserStatus,
+        },
+        timestamp: new Date(timestamp),
+        content,
+    };
+};
+
+const formatConversation = ({
+    id,
+    title,
+    created_at,
+    participants,
+    last_message,
+    total_messages,
+    unread_count,
+    is_custom_title,
+}: ConversationApiPayload): Conversation => {
+    return {
+        id,
+        title,
+        createdAt: new Date(created_at),
+        participants: participants.map((participant) => ({
+            id: participant.user_id,
+            displayName: participant.display_name,
+            email: participant.email || '',
+            status: (participant.status || 'offline') as UserStatus,
+        })),
+        lastMessage: last_message ? formatMessage(last_message) : null,
+        loadedMessages: [],
+        totalMessages: total_messages,
+        unreadCount: unread_count,
+        isCustomTitle: is_custom_title,
+    };
+};
+
+const formatConversationFromBaseData = ({
+    id,
+    title,
+    created_at,
+    is_custom_title,
+}: BaseConversationApiPayload): Conversation => {
+    return {
+        id,
+        title,
+        createdAt: new Date(created_at),
+        participants: [],
+        lastMessage: null,
+        loadedMessages: [],
+        totalMessages: 0,
+        unreadCount: 0,
+        isCustomTitle: is_custom_title,
+    };
+};
+
+export const useConversationsApi = () => {
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    /**
+     * Fetches the conversations for a user.
+     * @param userId - The ID of the user.
+     * @returns The user's conversations.
+     * @throws Will throw an error if the fetch fails.
+     */
+    const fetchUserConversations = async (userId: string): Promise<FetchUserConversationsPayload> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/conversations`, {
+                headers: {
+                    'x-user-id': userId,
+                },
+            });
+            if (!response.ok) {
+                throw new Error(`Failed to fetch conversations: ${response.statusText}`);
+            }
+            const data: FetchUserConversationsApiPayload = await response.json();
+            return {
+                conversations: data.conversations.map(formatConversation),
+                total: data.total,
+            };
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to fetch conversations';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    /**
+     * Fetches a conversation by its ID.
+     * @param conversationId - The ID of the conversation.
+     * @returns The requested conversation.
+     * @throws Will throw an error if the fetch fails.
+     */
+    const getConversation = async (conversationId: string): Promise<Conversation> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/conversations/${conversationId}`, {
+                credentials: 'include',
+            });
+            if (!response.ok) {
+                throw new Error(`Failed to fetch conversation: ${response.statusText}`);
+            }
+            const data: ConversationApiPayload = await response.json();
+            return formatConversation(data);
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to fetch conversation';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    /**
+     * Creates a new conversation.
+     * @param param.title - The title of the conversation.
+     * @param param.creatorId - The ID of the user creating the conversation.
+     * @param param.participantIds - Optional array of user IDs to add as participants.
+     * @returns The created conversation.
+     * @throws Will throw an error if the creation fails.
+     */
+    const createConversation = async ({
+        title,
+        creatorId,
+        participantIds,
+    }: {
+        title?: string;
+        creatorId: string;
+        participantIds?: string[];
+    }): Promise<Conversation> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/conversations`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-user-id': creatorId,
+                },
+                body: JSON.stringify({
+                    ...(title ? { title } : {}),
+                    participantIds: participantIds || [],
+                }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to create conversation: ${response.statusText}`);
+            }
+
+            const data: BaseConversationApiPayload = await response.json();
+            return formatConversationFromBaseData(data);
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to create conversation';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    /**
+     * Adds a participant to a conversation.
+     * @param conversationId - The ID of the conversation.
+     * @param userId - The ID of the user to add.
+     * @throws Will throw an error if the operation fails.
+     */
+    const addParticipant = async (conversationId: string, userId: string): Promise<void> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/conversations/${conversationId}/participants`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                credentials: 'include',
+                body: JSON.stringify({ userId }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to add participant: ${response.statusText}`);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to add participant';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    /**
+     * Removes a participant from a conversation.
+     * @param conversationId - The ID of the conversation.
+     * @param participantId - The ID of the participant to remove.
+     * @throws Will throw an error if the operation fails.
+     */
+    const removeParticipant = async (conversationId: string, participantId: string): Promise<void> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(
+                `${API_BASE_URL}/conversations/${conversationId}/participants/${participantId}`,
+                {
+                    method: 'DELETE',
+                    credentials: 'include',
+                }
+            );
+
+            if (!response.ok) {
+                throw new Error(`Failed to remove participant: ${response.statusText}`);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to remove participant';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    /**
+     * Marks a message as read in a conversation.
+     * @param conversationId - The ID of the conversation.
+     * @param messageId - The ID of the message to mark as read.
+     * @throws Will throw an error if the operation fails.
+     */
+    const markAsRead = async (conversationId: string, messageId: string): Promise<void> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/conversations/${conversationId}/read`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                credentials: 'include',
+                body: JSON.stringify({ messageId }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to mark as read: ${response.statusText}`);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'Failed to mark as read';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    /**
+     * Updates a conversation's title.
+     * @param conversationId - The ID of the conversation to update.
+     * @param userId - The ID of the user making the request.
+     * @param title - The new title for the conversation. Set to null to clear the title.
+     * @throws Will throw an error if the update fails.
+     */
+    const updateConversation = async (conversationId: string, userId: string, title: string | null): Promise<void> => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetch(`${API_BASE_URL}/conversations/${conversationId}`, {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-user-id': userId,
+                },
+                body: JSON.stringify({ title }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Failed to update conversation: ${response.statusText}`);
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : 'An error occurred while updating conversation';
+            setError(errorMessage);
+            throw err;
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return {
+        fetchUserConversations,
+        getConversation,
+        createConversation,
+        updateConversation,
+        addParticipant,
+        removeParticipant,
+        markAsRead,
+        loading,
+        error,
+    };
+};

--- a/frontend/src/hooks/useUserSearch.ts
+++ b/frontend/src/hooks/useUserSearch.ts
@@ -4,9 +4,9 @@ import Fuse from 'fuse.js';
 
 import { User } from '../utils/types';
 
-const USERS_PER_PAGE = 4;
+const DEFAULT_USERS_PER_PAGE = 4;
 
-export function useUserSearch(users: User[]) {
+export function useUserSearch(users: User[], usersPerPage = DEFAULT_USERS_PER_PAGE) {
     const [searchQuery, setSearchQuery] = useState('');
     const [currentPage, setCurrentPage] = useState(1);
 
@@ -24,13 +24,13 @@ export function useUserSearch(users: User[]) {
         return fuse.search(searchQuery).map((result) => result.item);
     }, [searchQuery, users, fuse]);
 
-    const totalPages = Math.ceil(filteredUsers.length / USERS_PER_PAGE);
+    const totalPages = Math.ceil(filteredUsers.length / usersPerPage);
 
     const paginatedUsers = useMemo(() => {
-        const startIndex = (currentPage - 1) * USERS_PER_PAGE;
-        const endIndex = startIndex + USERS_PER_PAGE;
+        const startIndex = (currentPage - 1) * usersPerPage;
+        const endIndex = startIndex + usersPerPage;
         return filteredUsers.slice(startIndex, endIndex);
-    }, [filteredUsers, currentPage]);
+    }, [filteredUsers, currentPage, usersPerPage]);
 
     useEffect(() => {
         setCurrentPage(1);

--- a/frontend/src/providers/ConversationSocketProvider.tsx
+++ b/frontend/src/providers/ConversationSocketProvider.tsx
@@ -1,0 +1,305 @@
+import { createContext, useContext, useEffect, useState, useCallback, useRef, ReactNode } from 'react';
+
+import { io, Socket } from 'socket.io-client';
+import invariant from 'tiny-invariant';
+
+import { useUserConversations } from './UserConversationsProvider';
+
+import { Message, UserStatus } from '../utils/types';
+
+type ConversationSocketContextType = {
+    isConnected: boolean;
+    joinConversation: (conversationId: string) => void;
+    leaveConversation: () => void;
+    sendMessage: (content: string) => void;
+    sendTypingEvent: (isTyping: boolean) => void;
+    sendMessageReadEvent: (messageId: string) => void;
+    messages: Message[];
+    typingUsers: Map<string, { userName: string; timestamp: number }>;
+};
+
+type MessagePayload = {
+    id: string;
+    conversation_id: string;
+    author_id: string;
+    content: string;
+    timestamp: string;
+    edited_at?: string | null;
+    is_deleted: boolean;
+    created_at: string;
+    author_name: string;
+    author_email?: string;
+    author_status: string;
+};
+
+const formatMessage = ({
+    id,
+    author_id,
+    content,
+    timestamp,
+    author_name,
+    author_email,
+    author_status,
+}: MessagePayload): Message => ({
+    id,
+    author: {
+        id: author_id,
+        displayName: author_name,
+        email: author_email || '',
+        status: author_status as UserStatus,
+    },
+    content,
+    timestamp: new Date(timestamp),
+});
+
+const ConversationSocketContext = createContext<ConversationSocketContextType | undefined>(undefined);
+
+export const useConversationSocket = () => {
+    const context = useContext(ConversationSocketContext);
+    invariant(context, 'useConversationSocket must be used within a ConversationSocketProvider');
+    return context;
+};
+
+type Props = {
+    children: ReactNode;
+};
+
+function ConversationSocketProvider({ children }: Props) {
+    const { loggedInUser, activeConversation } = useUserConversations();
+
+    const [socket, setSocket] = useState<Socket | null>(null);
+    const [isConnected, setIsConnected] = useState(false);
+    const [isAuthenticated, setIsAuthenticated] = useState(false);
+    const [messages, setMessages] = useState<Message[]>([]);
+    const [typingUsers, setTypingUsers] = useState<Map<string, { userName: string; timestamp: number }>>(new Map());
+
+    const typingTimeoutRef = useRef<Map<string, number>>(new Map());
+    const activeConversationIdRef = useRef<string | null>(null);
+
+    const activeConversationId = activeConversation ? activeConversation.id : null;
+
+    // Keep ref in sync with activeConversationId
+    useEffect(() => {
+        activeConversationIdRef.current = activeConversationId;
+    }, [activeConversationId]);
+
+    const joinConversation = useCallback(
+        (conversationId: string) => {
+            if (!socket || !loggedInUser) return;
+
+            if (activeConversationId) {
+                socket.emit('leave_conversation', { conversationId: activeConversationId });
+            }
+
+            setMessages([]);
+            setTypingUsers(new Map());
+
+            socket.emit('join_conversation', {
+                conversationId,
+            });
+        },
+        [socket, loggedInUser, activeConversationId]
+    );
+
+    const leaveConversation = useCallback(() => {
+        if (!socket || !activeConversationId) return;
+
+        socket.emit('leave_conversation', { conversationId: activeConversationId });
+        setMessages([]);
+        setTypingUsers(new Map());
+    }, [socket, activeConversationId]);
+
+    const sendMessage = useCallback(
+        (content: string) => {
+            if (!socket || !loggedInUser || !activeConversationId) return;
+
+            socket.emit('send_message', {
+                conversationId: activeConversationId,
+                content,
+            });
+        },
+        [socket, loggedInUser, activeConversationId]
+    );
+
+    /**
+     * Sends typing event to the server for the current logged in user in the active conversation
+     */
+    const sendTypingEvent = useCallback(
+        (isTyping: boolean) => {
+            if (!socket || !loggedInUser || !activeConversationId) return;
+
+            socket.emit('typing', {
+                conversationId: activeConversationId,
+                isTyping,
+            });
+        },
+        [socket, loggedInUser, activeConversationId]
+    );
+
+    /**
+     * Sends message read event to the server to update the last read message for the current user
+     */
+    const sendMessageReadEvent = useCallback(
+        (messageId: string) => {
+            if (!socket || !loggedInUser || !activeConversationId) return;
+
+            socket.emit('message_read', {
+                conversationId: activeConversationId,
+                messageId,
+            });
+        },
+        [socket, loggedInUser, activeConversationId]
+    );
+
+    useEffect(() => {
+        if (!loggedInUser) {
+            if (socket) {
+                socket.disconnect();
+                setSocket(null);
+                setIsConnected(false);
+                setIsAuthenticated(false);
+            }
+            return;
+        }
+
+        const timeoutsMap = typingTimeoutRef.current;
+
+        const socketUrl = import.meta.env.VITE_WS_URL || 'http://localhost:3001';
+
+        const newSocket = io(socketUrl, {
+            transports: ['websocket'],
+            auth: {
+                userId: loggedInUser.id, // Pass auth in handshake
+            },
+        });
+
+        newSocket.on('connect', () => {
+            setIsConnected(true);
+            // Authentication happens automatically via middleware
+        });
+
+        newSocket.on('authenticated', (data: { success: boolean; userId?: string; error?: string }) => {
+            if (data.success) {
+                setIsAuthenticated(true);
+            } else {
+                console.error('Socket authentication failed:', data.error);
+                setIsAuthenticated(false);
+            }
+        });
+
+        newSocket.on('connect_error', (error) => {
+            console.error('Socket connection error:', error.message);
+            setIsAuthenticated(false);
+            setIsConnected(false);
+        });
+
+        newSocket.on('disconnect', () => {
+            setIsConnected(false);
+        });
+
+        newSocket.on('conversation_history', (data: { conversationId: string; messages: MessagePayload[] }) => {
+            if (data.conversationId === activeConversationIdRef.current) {
+                setMessages(data.messages.map(formatMessage));
+            }
+        });
+
+        newSocket.on('new_message', (data: { conversationId: string; message: MessagePayload }) => {
+            if (data.conversationId === activeConversationIdRef.current) {
+                setMessages((prev) => [...prev, formatMessage(data.message)]);
+            }
+        });
+
+        newSocket.on(
+            'user_typing',
+            (data: { conversationId: string; userId: string; userName: string; isTyping: boolean }) => {
+                if (data.conversationId === activeConversationIdRef.current && data.userId !== loggedInUser.id) {
+                    setTypingUsers((prev) => {
+                        const newMap = new Map(prev);
+
+                        if (data.isTyping) {
+                            newMap.set(data.userId, {
+                                userName: data.userName,
+                                timestamp: Date.now(),
+                            });
+
+                            const existingTimeout = timeoutsMap.get(data.userId);
+                            if (existingTimeout) {
+                                clearTimeout(existingTimeout);
+                            }
+
+                            const timeout = setTimeout(() => {
+                                setTypingUsers((p) => {
+                                    const m = new Map(p);
+                                    m.delete(data.userId);
+                                    return m;
+                                });
+                                timeoutsMap.delete(data.userId);
+                            }, 3000);
+
+                            timeoutsMap.set(data.userId, timeout);
+                        } else {
+                            newMap.delete(data.userId);
+                            const timeout = timeoutsMap.get(data.userId);
+                            if (timeout) {
+                                clearTimeout(timeout);
+                                timeoutsMap.delete(data.userId);
+                            }
+                        }
+
+                        return newMap;
+                    });
+                }
+            }
+        );
+
+        newSocket.on('message_read_updated', (data: { conversationId: string; messageId: string; userId: string }) => {
+            console.log('Message read updated:', data);
+        });
+
+        newSocket.on('user_read_message', (data: { conversationId: string; messageId: string; userId: string }) => {
+            console.log('User read message:', data);
+            // Could be used to show read receipts in the future
+        });
+
+        newSocket.on('error', (data: { message: string }) => {
+            console.error('Socket error:', data.message);
+        });
+
+        setSocket(newSocket);
+
+        return () => {
+            timeoutsMap.forEach((timeout) => clearTimeout(timeout));
+            timeoutsMap.clear();
+            newSocket.disconnect();
+        };
+    }, [loggedInUser]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        if (isAuthenticated && activeConversationId) {
+            joinConversation(activeConversationId);
+        }
+
+        return () => {
+            leaveConversation();
+        };
+    }, [activeConversationId, isAuthenticated]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return (
+        <ConversationSocketContext.Provider
+            value={{
+                isConnected,
+                joinConversation,
+                leaveConversation,
+                sendMessage,
+                sendTypingEvent,
+                sendMessageReadEvent,
+                messages,
+                typingUsers,
+            }}
+        >
+            {children}
+        </ConversationSocketContext.Provider>
+    );
+}
+
+export default ConversationSocketProvider;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,0 +1,4 @@
+export const MAX_TITLE_LENGTH = 400;
+export const MAX_MESSAGE_LENGTH = 2000;
+export const MAX_PARTICIPANTS = 10;
+export const MESSAGE_GROUP_THRESHOLD_MS = 2 * 60 * 1000; // 2 minutes

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -4,8 +4,8 @@ export interface User {
     id: string;
     displayName: string;
     email: string;
-    createdAt: Date;
-    lastSeen: Date;
+    createdAt?: Date;
+    lastSeen?: Date;
     status: UserStatus;
 }
 
@@ -16,13 +16,17 @@ export interface Message {
     content: string;
 }
 
-export interface Conversation {
+export interface ConversationMetadata {
     id: string;
     title: string;
+    lastMessage: Message | null;
+    unreadCount: number;
+    isCustomTitle: boolean;
+}
+
+export interface Conversation extends ConversationMetadata {
     createdAt: Date;
     participants: User[];
     loadedMessages: Message[];
     totalMessages: number;
-    unreadCount: number;
-    lastMessage: Message | null;
 }


### PR DESCRIPTION
This pull request introduces major improvements to the conversations and messaging infrastructure in the frontend. The most important changes are the addition of a new API hook for conversation management, a real-time socket provider for messaging, and the refactor of user and conversation state management to use these new APIs. There are also improvements to user search pagination and better separation of mock data from production logic.

### Conversations and Messaging Infrastructure

* Added `useConversationsApi` hook to encapsulate all conversation-related API calls, including fetching, creating, updating conversations, managing participants, and marking messages as read. This provides a consistent and reusable way to interact with the backend API for conversations.
* Implemented `ConversationSocketProvider` for real-time messaging using Socket.IO, supporting joining/leaving conversations, sending messages and typing events, and handling read receipts. This enables live chat functionality and user presence updates.

### State Management Refactor

* Refactored `UserConversationsProvider` to use the new `useConversationsApi` hook for fetching and managing conversations, replacing the previous reliance on mock data. Added state for tracking loading and refetching, and ensured that active conversations are updated when the loaded conversations change. [[1]](diffhunk://#diff-ab7bd987d98528109389419adc608a59781110b416c996ad31a36992675aa9f5L1-R5) [[2]](diffhunk://#diff-ab7bd987d98528109389419adc608a59781110b416c996ad31a36992675aa9f5R16-R17) [[3]](diffhunk://#diff-ab7bd987d98528109389419adc608a59781110b416c996ad31a36992675aa9f5L32-R43) [[4]](diffhunk://#diff-ab7bd987d98528109389419adc608a59781110b416c996ad31a36992675aa9f5R57-R74)

### User Search Improvements

* Updated `useUserSearch` to allow configurable pagination size via a new `usersPerPage` parameter, improving flexibility for paginating user lists. [[1]](diffhunk://#diff-12adc3b86ffeb82e51a00468ad558fa56b4c635b19b8a839850f139d58aff9d9L7-R9) [[2]](diffhunk://#diff-12adc3b86ffeb82e51a00468ad558fa56b4c635b19b8a839850f139d58aff9d9L27-R33)