### PR TITLE
add filtering of empty unowned conversations

### DIFF
--- a/backend/src/controllers/conversationController.ts
+++ b/backend/src/controllers/conversationController.ts
@@ -13,6 +13,35 @@ export interface UserConversation extends ConversationWithParticipants {
     total_messages: number;
 }
 
+/**
+ * Get all conversations for the authenticated user with metadata
+ *
+ * By default, filters out empty conversations not created by the user.
+ * This ensures participants only see conversations once a message has been sent,
+ * while creators can see their own empty conversations.
+ *
+ * @param req - Express request object
+ * @param req.query.limit - Maximum number of conversations to return (default: 50)
+ * @param req.query.offset - Number of conversations to skip for pagination (default: 0)
+ * @param req.user.id - Authenticated user ID (required)
+ *
+ * @param res - Express response object
+ * @returns JSON response with:
+ *   - conversations: Array of conversation objects with:
+ *     - id: Conversation ID
+ *     - title: Conversation title (generated based on participants' names unless is_custom_title is true)
+ *     - created_at: Timestamp of creation
+ *     - created_by: User ID of creator
+ *     - is_custom_title: Whether the title was custom set
+ *     - participants: Array of participant details
+ *     - unread_count: Number of unread messages for the user
+ *     - last_message: Most recent message in the conversation (or null)
+ *     - total_messages: Total count of messages in the conversation
+ *   - total: Total count of conversations for the user (respecting the same filter)
+ *
+ * @throws 401 - If user is not authenticated
+ * @throws 500 - If database operation fails
+ */
 export async function getConversationsForUser(req: Request, res: Response): Promise<void> {
     try {
         const userId = req.user?.id;


### PR DESCRIPTION
This pull request enhances how user conversations are retrieved by introducing a flexible filter for empty conversations. Now, users only see conversations they created or those with messages, unless explicitly requested. These changes improve both backend filtering and API documentation for conversation retrieval.

**Conversation retrieval logic:**

* Added an `includeEmptyUnowned` parameter to `ConversationService.getConversationsForUser` and `getConversationsCountForUser` to control whether empty conversations not created by the user are included. The default behavior now filters out these conversations unless requested. [[1]](diffhunk://#diff-957483796028288d962fc851740ce133cd65a1545c95a1bc671f013cd4ec1b1fR108-R134) [[2]](diffhunk://#diff-957483796028288d962fc851740ce133cd65a1545c95a1bc671f013cd4ec1b1fR151-R172)

**API documentation and interface improvements:**

* Added detailed JSDoc documentation to the `getConversationsForUser` controller, explaining the new filtering behavior, parameters, and response structure for better developer clarity.