### PR TITLE
emit conv_meta_updated after every send_message

### DIFF
--- a/frontend/src/providers/UserConversationsProvider.tsx
+++ b/frontend/src/providers/UserConversationsProvider.tsx
@@ -15,6 +15,7 @@ export type UserContextType = {
     totalConversations: number;
     refetchConversations: () => Promise<void>;
     isFetchingConversations: boolean;
+    updateConversation: (newData: Partial<Conversation>) => void;
 };
 
 const UserConversationsContext = createContext<UserContextType | undefined>(undefined);
@@ -54,6 +55,20 @@ function UserConversationsProvider({ children }: { children: ReactNode }) {
         setActiveConversation(conversation);
     };
 
+    const updateConversation = (newData: Partial<Conversation>) => {
+        setActiveConversation((prevConversation) => {
+            if (!prevConversation) return prevConversation;
+            if (!newData.id || prevConversation.id !== newData.id) return prevConversation;
+            return { ...prevConversation, ...newData };
+        });
+        setLoadedConversations((prevConversations) => {
+            return prevConversations.map((conversation) => {
+                if (!newData.id || conversation.id !== newData.id) return conversation;
+                return { ...conversation, ...newData };
+            });
+        });
+    };
+
     const fetchConversations = async () => {
         if (loggedInUser) {
             try {
@@ -84,6 +99,7 @@ function UserConversationsProvider({ children }: { children: ReactNode }) {
                 totalConversations,
                 refetchConversations: fetchConversations,
                 isFetchingConversations,
+                updateConversation,
             }}
         >
             {children}

--- a/frontend/src/utils/formatters.ts
+++ b/frontend/src/utils/formatters.ts
@@ -1,12 +1,23 @@
 import { formatDistanceToNowStrict, format } from 'date-fns';
 
+const JUST_NOW_THRESHOLD_SECONDS = 10;
+
 /**
  * Formats a date into a human-readable relative time string.
  * @param date The date to format.
- * @returns The formatted relative time string. (e.g., "5min ago", "2h ago", "3d ago")
+ * @returns The formatted relative time string. (e.g., "Just now", "5min ago", "2h ago", "3d ago")
  */
 export const formatRelativeTime = (date: Date): string => {
-    const distance = formatDistanceToNowStrict(new Date(date), {
+    const now = new Date();
+    const dateObj = new Date(date);
+    const secondsAgo = Math.floor((now.getTime() - dateObj.getTime()) / 1000);
+
+    // Return "Just now" for messages less than 10 seconds old
+    if (secondsAgo < JUST_NOW_THRESHOLD_SECONDS) {
+        return 'Just now';
+    }
+
+    const distance = formatDistanceToNowStrict(dateObj, {
         addSuffix: true,
     });
 

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,12 +1,15 @@
 export type UserStatus = 'online' | 'away' | 'offline';
 
-export interface User {
-    id: string;
-    displayName: string;
-    email: string;
+export interface UserMetadata {
+    email?: string;
     createdAt?: Date;
     lastSeen?: Date;
-    status: UserStatus;
+    status?: UserStatus;
+}
+
+export interface User extends UserMetadata {
+    id: string;
+    displayName: string;
 }
 
 export interface Message {


### PR DESCRIPTION
This pull request introduces improvements to the messaging and conversation system, focusing on more efficient unread message count updates, consistent message payload formatting, and enhanced frontend state synchronization. The backend now emits real-time unread counts and last message metadata to all conversation participants, while the frontend updates conversation state accordingly. Additionally, message payloads are standardized across the backend and frontend, and relative time formatting is improved for recent messages.

**Backend improvements:**

* Added `getUnreadCountForConversation` method to `ConversationService` to efficiently fetch unread message counts for multiple users in a conversation.
* Updated socket event handlers in `chatSocket.ts` to:
  - Format messages with a nested `author` object for consistency.
  - Emit `conversation_meta_updated` events to each participant with unread count and last message data after a new message is sent. [[1]](diffhunk://#diff-848300d4ca3b3efc8c6448b04c4896e6236a03680b10fb7b92c263fffcf06d2eR96-R169) [[2]](diffhunk://#diff-848300d4ca3b3efc8c6448b04c4896e6236a03680b10fb7b92c263fffcf06d2eR32-R41)

**Frontend enhancements:**

* Standardized `MessagePayload` and `User` types, simplifying message formatting and ensuring consistent author representation. [[1]](diffhunk://#diff-e656c1da881a0e7ec92a2f0b0897ac85c38a9ef463c53aa671b4415f7babdd5fL23-R33) [[2]](diffhunk://#diff-436803a8374ad179585c5e7089a119edf31315c67ff63373320ff1b1d955b3d7L3-R12)
* Added `updateConversation` method to `UserConversationsProvider` and integrated it into the socket provider to update conversation metadata (last message, unread count, title) in real time. [[1]](diffhunk://#diff-ab7bd987d98528109389419adc608a59781110b416c996ad31a36992675aa9f5R58-R71) [[2]](diffhunk://#diff-ab7bd987d98528109389419adc608a59781110b416c996ad31a36992675aa9f5R102) [[3]](diffhunk://#diff-e656c1da881a0e7ec92a2f0b0897ac85c38a9ef463c53aa671b4415f7babdd5fL68-R48) [[4]](diffhunk://#diff-e656c1da881a0e7ec92a2f0b0897ac85c38a9ef463c53aa671b4415f7babdd5fL200-R222)

**User experience improvements:**

* Improved relative time formatting for messages, displaying "Just now" for messages sent within the last 10 seconds.