### PR TITLE
implement message reading in tui

### DIFF
--- a/backend/src/db/init.ts
+++ b/backend/src/db/init.ts
@@ -29,11 +29,11 @@ async function initializeDatabase(skipPrompt = false) {
 
     // Check if tables exist
     const existingTables = await sql`
-    SELECT table_name 
-    FROM information_schema.tables 
-    WHERE table_schema = 'public' 
-    AND table_name IN ('users', 'conversations', 'messages', 'conversation_participants')
-  `;
+      SELECT table_name 
+      FROM information_schema.tables 
+      WHERE table_schema = 'public' 
+      AND table_name IN ('users', 'conversations', 'messages', 'conversation_participants')
+    `;
 
     // Prompt for confirmation if tables exist and not skipping prompt
     if (!skipPrompt && existingTables.length > 0) {
@@ -68,54 +68,54 @@ async function initializeDatabase(skipPrompt = false) {
         // Create users table
         console.log('Creating users table...');
         await sql`
-      CREATE TABLE users (
-        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-        display_name VARCHAR(255) NOT NULL,
-        email VARCHAR(255) UNIQUE,
-        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        status user_status DEFAULT 'offline',
-        last_seen TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-      )
-    `;
+          CREATE TABLE users (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            display_name VARCHAR(255) NOT NULL,
+            email VARCHAR(255) UNIQUE,
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+            status user_status DEFAULT 'offline',
+            last_seen TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+          )
+        `;
 
         // Create conversations table
         console.log('Creating conversations table...');
         await sql`
-      CREATE TABLE conversations (
-        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-        title VARCHAR(255),
-        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        created_by UUID REFERENCES users(id) ON DELETE SET NULL
-      )
-    `;
+          CREATE TABLE conversations (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            title VARCHAR(255),
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+            created_by UUID REFERENCES users(id) ON DELETE SET NULL
+          )
+        `;
 
         // Create messages table
         console.log('Creating messages table...');
         await sql`
-      CREATE TABLE messages (
-        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-        conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
-        author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-        content TEXT NOT NULL,
-        timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        edited_at TIMESTAMP WITH TIME ZONE,
-        is_deleted BOOLEAN DEFAULT FALSE,
-        created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
-      )
-    `;
+          CREATE TABLE messages (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+            author_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            content TEXT NOT NULL,
+            timestamp TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+            edited_at TIMESTAMP WITH TIME ZONE,
+            is_deleted BOOLEAN DEFAULT FALSE,
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+          )
+        `;
 
         // Create conversation_participants table
         console.log('Creating conversation_participants table...');
         await sql`
-      CREATE TABLE conversation_participants (
-        conversation_id UUID REFERENCES conversations(id) ON DELETE CASCADE,
-        user_id UUID REFERENCES users(id) ON DELETE CASCADE,
-        joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-        last_read_message_id UUID REFERENCES messages(id) ON DELETE SET NULL,
-        is_admin BOOLEAN DEFAULT FALSE,
-        PRIMARY KEY (conversation_id, user_id)
-      )
-    `;
+          CREATE TABLE conversation_participants (
+            conversation_id UUID REFERENCES conversations(id) ON DELETE CASCADE,
+            user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+            joined_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+            last_read_message_id UUID REFERENCES messages(id) ON DELETE SET NULL,
+            is_admin BOOLEAN DEFAULT FALSE,
+            PRIMARY KEY (conversation_id, user_id)
+          )
+        `;
 
         // Create indexes
         console.log('Creating indexes...');
@@ -130,11 +130,11 @@ async function initializeDatabase(skipPrompt = false) {
 
         // Verify tables were created
         const tables = await sql`
-      SELECT table_name 
-      FROM information_schema.tables 
-      WHERE table_schema = 'public' 
-      ORDER BY table_name
-    `;
+          SELECT table_name 
+          FROM information_schema.tables 
+          WHERE table_schema = 'public' 
+          ORDER BY table_name
+        `;
 
         console.log(`Created ${tables.length} tables:`, tables.map((t) => t.table_name).join(', '));
     } catch (error) {

--- a/terminal-client/src/providers/WebSocketProvider.tsx
+++ b/terminal-client/src/providers/WebSocketProvider.tsx
@@ -41,6 +41,7 @@ type WebSocketContextValue = {
             lastReadMessage: MessagePayload | null;
         }) => void
     ) => () => void;
+    subscribeToReadUpdate: (callback: (data: { lastReadMessage: MessagePayload }) => void) => () => void;
 };
 
 const WebSocketContext = createContext<WebSocketContextValue | null>(null);
@@ -205,6 +206,13 @@ function WebSocketProvider({ children }: Props) {
         };
     };
 
+    const subscribeToReadUpdate = (callback: (data: { lastReadMessage: MessagePayload }) => void) => {
+        socketRef.current?.on('message_read_updated', callback);
+        return () => {
+            socketRef.current?.off('message_read_updated', callback);
+        };
+    };
+
     // Cleanup on unmount
     useEffect(() => {
         return () => {
@@ -226,6 +234,7 @@ function WebSocketProvider({ children }: Props) {
         subscribeToTyping,
         subscribeToMetaUpdates,
         subscribeToHistory,
+        subscribeToReadUpdate,
     };
 
     return <WebSocketContext.Provider value={value}>{children}</WebSocketContext.Provider>;

--- a/terminal-client/src/screens/Conversation.tsx
+++ b/terminal-client/src/screens/Conversation.tsx
@@ -83,6 +83,8 @@ function Conversation({ user, conversationId, onBack }: Props) {
         subscribeToHistory,
         subscribeToNewMessages,
         subscribeToTyping,
+        subscribeToReadUpdate,
+        markMessageAsRead,
         isConnected,
     } = useWebSocket();
 
@@ -101,6 +103,7 @@ function Conversation({ user, conversationId, onBack }: Props) {
     const [scrollOffset, setScrollOffset] = useState(0);
     const messagesEndRef = useRef<number>(0);
     const [showCommands, setShowCommands] = useState(false);
+    const lastMarkedAsReadRef = useRef<{ messageId: string; timestamp: Date } | null>(null);
 
     const loadConversation = async () => {
         try {
@@ -226,7 +229,7 @@ function Conversation({ user, conversationId, onBack }: Props) {
         joinConversation(conversationId);
 
         // Subscribe to conversation history
-        const unsubHistory = subscribeToHistory(({ messages: historyMessages }) => {
+        const unsubHistory = subscribeToHistory(({ messages: historyMessages, lastReadMessage }) => {
             const formattedMessages: Message[] = historyMessages.map((message) => ({
                 messageId: message.id,
                 conversationId,
@@ -240,6 +243,15 @@ function Conversation({ user, conversationId, onBack }: Props) {
                 },
             }));
             setMessages(formattedMessages);
+
+            // Store the last read message ID and timestamp from server
+            if (lastReadMessage) {
+                lastMarkedAsReadRef.current = {
+                    messageId: lastReadMessage.id,
+                    timestamp: new Date(lastReadMessage.timestamp),
+                };
+            }
+
             setLoading(false);
         });
 
@@ -263,6 +275,15 @@ function Conversation({ user, conversationId, onBack }: Props) {
         // Subscribe to typing events
         const unsubTyping = subscribeToTyping(handleTypingUpdate);
 
+        // Subscribe to read updates
+        const unsubReadUpdate = subscribeToReadUpdate(({ lastReadMessage }) => {
+            // Update our tracking when server confirms the read
+            lastMarkedAsReadRef.current = {
+                messageId: lastReadMessage.id,
+                timestamp: new Date(lastReadMessage.timestamp),
+            };
+        });
+
         // Load conversation metadata
         loadConversation();
 
@@ -271,6 +292,7 @@ function Conversation({ user, conversationId, onBack }: Props) {
             unsubHistory();
             unsubNewMsg();
             unsubTyping();
+            unsubReadUpdate();
 
             // Clear typing timeouts using captured ref value
             timeoutsMap.forEach((timeout) => clearTimeout(timeout));
@@ -295,6 +317,36 @@ function Conversation({ user, conversationId, onBack }: Props) {
         messagesEndRef.current = messages.length;
         setScrollOffset(Math.max(0, messages.length - messagesViewHeight));
     }, [messages.length, messagesViewHeight]);
+
+    // Mark messages as read when they become visible
+    useEffect(() => {
+        if (!isConnected || messages.length === 0) return;
+
+        // Calculate currently visible messages
+        const visibleMessageSlice = messages.slice(scrollOffset, scrollOffset + messagesViewHeight);
+        if (visibleMessageSlice.length === 0) return;
+
+        // Find the last visible message that isn't from the current user or system
+        const lastVisibleMessage = visibleMessageSlice
+            .filter(({ authorId }) => authorId !== user.userId && authorId !== 'system')
+            .pop();
+
+        if (!lastVisibleMessage) return;
+
+        const { messageId, createdAt } = lastVisibleMessage;
+        const messageTimestamp = new Date(createdAt);
+
+        // Only mark as read if it's a newer message than what we've already marked
+        if (lastMarkedAsReadRef.current?.messageId === messageId) return;
+
+        // Check if this message is newer than our last marked message
+        const isNewer = !lastMarkedAsReadRef.current || messageTimestamp > lastMarkedAsReadRef.current.timestamp;
+
+        if (isNewer) {
+            markMessageAsRead(conversationId, messageId);
+            // Note: We don't update lastMarkedAsReadRef here because we wait for server confirmation
+        }
+    }, [scrollOffset, messages, messagesViewHeight, isConnected, conversationId, user.userId, markMessageAsRead]);
 
     useInput((_input, key) => {
         if (key.escape) {

--- a/terminal-client/tsconfig.json
+++ b/terminal-client/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "ES2022",
         "module": "NodeNext",
         "moduleResolution": "NodeNext",
-        "lib": ["ES2022"],
+        "lib": ["ES2023"],
         "jsx": "react-jsx",
         "declaration": true,
         "declarationMap": true,


### PR DESCRIPTION
This pull request adds a robust mechanism for tracking and updating the "last read" message in conversations, ensuring the client and server remain in sync about which messages have been read. The changes introduce a new subscription for read updates, update the conversation state accordingly, and implement logic to mark messages as read when they become visible to the user.

**Read status synchronization improvements:**

* Added a new `subscribeToReadUpdate` method to the `WebSocketProvider` context, allowing components to listen for server-side updates about the last read message. (`terminal-client/src/providers/WebSocketProvider.tsx`) [[1]](diffhunk://#diff-159efdf3608f9cf8fcaf5f9964630d25d00d92a75177d32a64ea69db04740d4bR44) [[2]](diffhunk://#diff-159efdf3608f9cf8fcaf5f9964630d25d00d92a75177d32a64ea69db04740d4bR209-R215) [[3]](diffhunk://#diff-159efdf3608f9cf8fcaf5f9964630d25d00d92a75177d32a64ea69db04740d4bR237)
* Updated the `Conversation` screen to subscribe to read updates and maintain a local reference (`lastMarkedAsReadRef`) to track the last message confirmed as read by the server. (`terminal-client/src/screens/Conversation.tsx`) [[1]](diffhunk://#diff-d5a808191a48f9d4464fc72b55ac4af7f7b8eaebd6519f078ce525d08692be1eR106) [[2]](diffhunk://#diff-d5a808191a48f9d4464fc72b55ac4af7f7b8eaebd6519f078ce525d08692be1eR278-R286)

**Conversation history and state management:**

* Modified the history subscription to include `lastReadMessage` from the server, updating the local tracking reference whenever a new history or read update is received. (`terminal-client/src/screens/Conversation.tsx`) [[1]](diffhunk://#diff-d5a808191a48f9d4464fc72b55ac4af7f7b8eaebd6519f078ce525d08692be1eL229-R232) [[2]](diffhunk://#diff-d5a808191a48f9d4464fc72b55ac4af7f7b8eaebd6519f078ce525d08692be1eR246-R254)

**Automatic marking of visible messages as read:**

* Implemented logic to automatically mark the most recent visible message (not authored by the current user or system) as read when it appears in the viewport, only if it is newer than the last confirmed read message. This ensures accurate read receipts and avoids redundant updates. (`terminal-client/src/screens/Conversation.tsx`)

**Resource cleanup:**

* Ensured all subscriptions, including the new read update subscription, are properly cleaned up when the `Conversation` component unmounts. (`terminal-client/src/screens/Conversation.tsx`)